### PR TITLE
chore: remove list-all from incoming payment grant

### DIFF
--- a/grant/grant-incoming-payment.js
+++ b/grant/grant-incoming-payment.js
@@ -31,7 +31,7 @@ const grant = await client.grant.request(
             access: [
                 {
                     type: "incoming-payment",
-                    actions: ["list", "list-all", "read", "read-all", "complete", "create"],
+                    actions: ["list", "read", "read-all", "complete", "create"],
                 },
             ],
         },

--- a/grant/grant-incoming-payment.ts
+++ b/grant/grant-incoming-payment.ts
@@ -38,7 +38,7 @@ const grant = await client.grant.request(
             access: [
                 {
                     type: "incoming-payment",
-                    actions: ["list", "list-all", "read", "read-all", "complete", "create"],
+                    actions: ["list", "read", "read-all", "complete", "create"],
                 },
             ],
         },


### PR DESCRIPTION
Closes #2.

The `list-all` action needs the interaction property which we are not providing when requesting the incoming payment grant. Should this be a separate snippet?

For the OP docs I think we should mention this somewhere. For the SDK, we should probably update the types for the request payload. This way it can raise a type error if `list-all` is provided and the `interaction` is missing and vice versa.

On the other hand, `read-all` should also require an interaction since it allows to ready ANY incoming payment.
