### PR TITLE
clarify outgoing payment grant request

### DIFF
--- a/grant/grant-outgoing-payment.js
+++ b/grant/grant-outgoing-payment.js
@@ -31,9 +31,6 @@ const quote = await client.quote.get({
     accessToken: QUOTE_ACCESS_TOKEN,
 });
 
-const DEBIT_AMOUNT = quote.debitAmount;
-const RECEIVE_AMOUNT = quote.receiveAmount;
-
 const grant = await client.grant.request(
     {
         url: walletAddress.authServer,
@@ -46,8 +43,11 @@ const grant = await client.grant.request(
                     type: "outgoing-payment",
                     actions: ["list", "list-all", "read", "read-all", "create"],
                     limits: {
-                        debitAmount: DEBIT_AMOUNT,
-                        receiveAmount: RECEIVE_AMOUNT,
+                        debitAmount: {
+                            assetCode: quote.debitAmount.assetCode,
+                            assetScale: quote.debitAmount.assetScale,
+                            value: quote.debitAmount.value
+                        }
                     },
                 },
             ],

--- a/grant/grant-outgoing-payment.ts
+++ b/grant/grant-outgoing-payment.ts
@@ -37,8 +37,6 @@ const quote = await client.quote.get({
     accessToken: QUOTE_ACCESS_TOKEN,
 });
 
-const DEBIT_AMOUNT = quote.debitAmount;
-const RECEIVE_AMOUNT = quote.receiveAmount;
 
 //@! start chunk 4 | title=Request outgoing payment grant
 const grant = await client.grant.request(
@@ -53,8 +51,11 @@ const grant = await client.grant.request(
                     type: "outgoing-payment",
                     actions: ["list", "list-all", "read", "read-all", "create"],
                     limits: {
-                        debitAmount: DEBIT_AMOUNT,
-                        receiveAmount: RECEIVE_AMOUNT,
+                        debitAmount: {
+                            assetCode: quote.debitAmount.assetCode,
+                            assetScale: quote.debitAmount.assetScale,
+                            value: quote.debitAmount.value
+                        }
                     },
                 },
             ],


### PR DESCRIPTION
- Simplify outgoing payment grant creation snippet by fully writing out the debitAmount object
- Reoving receiveAmount object for clarity (we wont be supporting both debitAmount and receiveAmount) in the same request
- 